### PR TITLE
Expose voice user API and improve tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,25 @@ node index.js
 
 Optional environment variables `GUILD_ID` and `VOICE_CHANNEL_ID` let the bot auto-join a voice channel on startup.
 
+### Voice user API
+
+When the bot is running it also exposes a small HTTP endpoint that returns the people currently connected to the tracked voice
+channel. The server listens on `0.0.0.0:3000` by default. You can customise the binding through the optional environment
+variables `VOICE_API_PORT` (or `API_PORT`/`PORT`) and `VOICE_API_HOST`.
+
+```
+GET /api/voice/users
+```
+
+Query parameters:
+
+- `guildId` and `channelId` (optional) target a specific guild/channel combination. When omitted, the bot falls back to the
+  auto-join environment variables or the last joined voice channel.
+- `refresh` (`1`/`true`) forces the bot to re-synchronise the user list with Discord before returning the payload.
+
+The endpoint responds with a JSON payload containing the guild/channel metadata, `count`, and an array of user snapshots
+(`id`, `displayName`, `username`, `mute`/`deaf` flags, etc.).
+
 ## Docker
 
 A Dockerfile and docker-compose.yml are included. Build and run with:


### PR DESCRIPTION
## Summary
- add an HTTP endpoint that exposes the tracked voice channel users and optional refresh/query parameters
- keep an up to date cache of voice channel occupants by syncing on join and listening to voiceStateUpdate events
- document the new voice user API and its configuration options in the README

## Testing
- node --check index.js

------
https://chatgpt.com/codex/tasks/task_e_68d05386ae048324ba9d4047517dc790