### PR TITLE
Allow configuring Jamendo music tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ export JAMENDO_CLIENT_ID="<your jamendo client id>"
 node index.js
 ```
 
-Optional environment variables `GUILD_ID` and `VOICE_CHANNEL_ID` let the bot auto-join a voice channel on startup.
+Optional environment variables `GUILD_ID` and `VOICE_CHANNEL_ID` let the bot auto-join a voice channel on startup. You can also
+set `JAMENDO_MUSIC_TAG` to choose the default Jamendo style (defaults to `ambient`). The music tag can be changed at runtime in
+Discord with the `--change-music-tag <tag>` command.
 
 ## Docker
 


### PR DESCRIPTION
## Summary
- make the Jamendo search tag configurable via the JAMENDO_MUSIC_TAG environment variable and the new --change-music-tag command
- track recently played Jamendo IDs per tag so switching styles keeps variety and update runtime logs accordingly
- document the new configuration option in the README

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d06688decc8324b21cbe1c9223404f