### PR TITLE
Set default Jamendo style to atmo and lower default volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Discord Background Music Bot
 
-This project runs a self-hosted Discord music helper that can automatically join a voice channel and stream ambient tracks from Jamendo.
+This project runs a self-hosted Discord music helper that can automatically join a voice channel and stream "atmo" tracks from Jamendo.
 
 ## Requirements
 
@@ -26,7 +26,7 @@ node index.js
 ```
 
 Optional environment variables `GUILD_ID` and `VOICE_CHANNEL_ID` let the bot auto-join a voice channel on startup. You can also
-set `JAMENDO_MUSIC_TAG` to choose the default Jamendo style (defaults to `ambient`). The music tag can be changed at runtime in
+set `JAMENDO_MUSIC_TAG` to choose the default Jamendo style (defaults to `atmo`). The music tag can be changed at runtime in
 Discord with the `--change-music-tag <tag>` command.
 
 ## Docker

--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ function sanitizeMusicTag(rawTag) {
   return trimmed.toLowerCase().replace(/\s+/g, '-');
 }
 
-const DEFAULT_JAMENDO_TAG = sanitizeMusicTag(process.env.JAMENDO_MUSIC_TAG) || 'ambient';
+const DEFAULT_JAMENDO_TAG = sanitizeMusicTag(process.env.JAMENDO_MUSIC_TAG) || 'atmo';
 let currentJamendoTag = DEFAULT_JAMENDO_TAG;
 
 if (!BOT_TOKEN || !JAMENDO_CLIENT_ID) {
@@ -111,7 +111,7 @@ const client = new Client({
 let voiceConnection = null;
 const player = createAudioPlayer({ behaviors: { noSubscriber: NoSubscriberBehavior.Play } });
 let currentResource = null;
-let currentVolume = 0.05; // 5% par défaut
+let currentVolume = 0.01; // 1% par défaut
 let lastTrackInfo = null;
 let manualStopInProgress = false;
 let autoPlaybackDesired = false;


### PR DESCRIPTION
## Summary
- set the default Jamendo music tag to "atmo"
- reduce the initial playback volume to 1%
- document the new defaults in the README

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d07834a628832487ce5e48f45691ec