### PR TITLE
Set default volume to 1 percent

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ node index.js
 ```
 
 Optional environment variables `GUILD_ID` and `VOICE_CHANNEL_ID` let the bot auto-join a voice channel on startup. You can also
-set `JAMENDO_MUSIC_TAG` to choose the default Jamendo style (defaults to `atmo`). The music tag can be changed at runtime in
-Discord with the `--change-music-tag <tag>` command.
+set `JAMENDO_MUSIC_TAG` to choose the default Jamendo style (defaults to `atmo`).
+
+The playback volume starts at **1%** by default. Override it with `DEFAULT_VOLUME_PERCENT` (values are clamped between 0 and 200).
+The music tag can be changed at runtime in Discord with the `--change-music-tag <tag>` command.
 
 ## Docker
 

--- a/index.js
+++ b/index.js
@@ -71,6 +71,25 @@ const JAMENDO_CLIENT_ID = process.env.JAMENDO_CLIENT_ID;
 const AUTO_GUILD_ID = process.env.GUILD_ID || null;
 const AUTO_VOICE_CHANNEL_ID = process.env.VOICE_CHANNEL_ID || null;
 
+function resolveDefaultVolumePercent() {
+  const rawValue = process.env.DEFAULT_VOLUME_PERCENT;
+  if (rawValue === undefined || rawValue === null || rawValue === '') {
+    return 1;
+  }
+
+  const parsed = Number(rawValue);
+  if (!Number.isFinite(parsed)) {
+    console.warn(
+      `DEFAULT_VOLUME_PERCENT invalide (« ${rawValue} »). La valeur 1% sera utilisée par défaut.`
+    );
+    return 1;
+  }
+
+  return Math.max(0, Math.min(200, parsed));
+}
+
+const DEFAULT_VOLUME_PERCENT = resolveDefaultVolumePercent();
+
 function sanitizeMusicTag(rawTag) {
   if (typeof rawTag !== 'string') return null;
   const trimmed = rawTag.trim();
@@ -87,6 +106,7 @@ if (!BOT_TOKEN || !JAMENDO_CLIENT_ID) {
 }
 
 console.log(`Tag Jamendo initial: ${currentJamendoTag}`);
+console.log(`Volume initial configuré à ${DEFAULT_VOLUME_PERCENT}%`);
 
 const ALLOWED_USER_ID = '216189520872210444';
 const ALLOWED_ROLE_NAMES = ['Radio', 'Modo', 'Medium'];
@@ -111,7 +131,7 @@ const client = new Client({
 let voiceConnection = null;
 const player = createAudioPlayer({ behaviors: { noSubscriber: NoSubscriberBehavior.Play } });
 let currentResource = null;
-let currentVolume = 0.01; // 1% par défaut
+let currentVolume = DEFAULT_VOLUME_PERCENT / 100; // 1% par défaut
 let lastTrackInfo = null;
 let manualStopInProgress = false;
 let autoPlaybackDesired = false;


### PR DESCRIPTION
## Summary
- resolve the playback volume default from a new DEFAULT_VOLUME_PERCENT env variable (defaults to 1%)
- log the configured default volume and reuse it when creating resources
- document the new environment variable in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2ce4cf1908324a8b7acc0e60bcf23