### PR TITLE
Set default playback volume to 1 percent

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ node index.js
 
 Optional environment variables `GUILD_ID` and `VOICE_CHANNEL_ID` let the bot auto-join a voice channel on startup. You can also
 set `JAMENDO_MUSIC_TAG` to choose the default Jamendo style (defaults to `atmo`). The music tag can be changed at runtime in
-Discord with the `--change-music-tag <tag>` command.
+Discord with the `--change-music-tag <tag>` command. Playback starts at 1% volume by default; override this by exporting
+`DEFAULT_VOLUME_PERCENT` (any value between 0 and 200).
 
 ## Docker
 


### PR DESCRIPTION
## Summary
- ensure playback volume defaults to 1% by deriving it from an optional DEFAULT_VOLUME_PERCENT env var
- reuse the new volume parsing helper for the --change-volume command and log the initial volume level
- document the default 1% level and how to override it in the README

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d2d318a83c8324836a238e5b78f1f1