### PR TITLE
Add support for playing YouTube URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ set `JAMENDO_MUSIC_TAG` to choose the default Jamendo style (defaults to `atmo`)
 Discord with the `--change-music-tag <tag>` command. Playback starts at 1% volume by default; override this by exporting
 `DEFAULT_VOLUME_PERCENT` (any value between 0 and 200).
 
+Use `--start-music <url>` to stream a custom audio source. The bot understands direct audio links as well as YouTube URLs.
+
 ## Docker
 
 A Dockerfile and docker-compose.yml are included. Build and run with:


### PR DESCRIPTION
## Summary
- detect YouTube URLs provided to `--start-music` and stream them with ytdl-core
- share richer playback details in channel announcements for any custom source
- document YouTube playback support in the README

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6b5e3fa68832490f13e34f4cb8ab8