### PR TITLE
Increase default message deletion delay

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ function parseDeleteDelay(rawValue, fallback) {
   return normalized;
 }
 
-const MESSAGE_DELETE_DELAY_MS = parseDeleteDelay(process.env.MESSAGE_DELETE_DELAY_MS, 1_000);
+const MESSAGE_DELETE_DELAY_MS = parseDeleteDelay(process.env.MESSAGE_DELETE_DELAY_MS, 15_000);
 
 function parseVolumePercent(rawValue) {
   if (rawValue === undefined || rawValue === null || rawValue === '') {


### PR DESCRIPTION
## Summary
- update the default auto-delete delay to 15 seconds so messages persist longer before removal

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d91bc0d978832497f532a9f5c515e7