### PR TITLE
Handle YouTube consent requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Discord with the `--change-music-tag <tag>` command. Playback starts at 1% volum
 `DEFAULT_VOLUME_PERCENT` (any value between 0 and 200).
 
 Use `--start-music <url>` to stream a custom audio source. The bot understands direct audio links as well as YouTube URLs.
+When streaming YouTube, the bot now sends a consent cookie by default so that regions requiring GDPR consent do not return HTTP
+410 errors. Override the cookie value with `YOUTUBE_CONSENT_COOKIE` if you need a different one or want to provide a full `CONSENT`
+string from your own browser session.
 
 ## Docker
 

--- a/index.js
+++ b/index.js
@@ -435,11 +435,34 @@ function isYoutubeUrl(input) {
   return YOUTUBE_HOST_SUFFIXES.some((suffix) => hostname === suffix || hostname.endsWith(`.${suffix}`));
 }
 
-const YOUTUBE_REQUEST_HEADERS = Object.freeze({
+function normalizeYoutubeConsentCookie(rawValue) {
+  if (typeof rawValue !== 'string') {
+    return null;
+  }
+  const trimmed = rawValue.trim();
+  if (!trimmed) {
+    return null;
+  }
+  return trimmed;
+}
+
+const DEFAULT_YOUTUBE_CONSENT_COOKIE = 'SOCS=CAI';
+const YOUTUBE_CONSENT_COOKIE =
+  normalizeYoutubeConsentCookie(process.env.YOUTUBE_CONSENT_COOKIE) || DEFAULT_YOUTUBE_CONSENT_COOKIE;
+
+const youtubeRequestHeaders = {
   'User-Agent':
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
-  'Accept-Language': 'en-US,en;q=0.9'
-});
+  'Accept-Language': 'en-US,en;q=0.9',
+  Accept: '*/*',
+  Referer: 'https://www.youtube.com'
+};
+
+if (YOUTUBE_CONSENT_COOKIE) {
+  youtubeRequestHeaders.Cookie = YOUTUBE_CONSENT_COOKIE;
+}
+
+const YOUTUBE_REQUEST_HEADERS = Object.freeze(youtubeRequestHeaders);
 
 async function getYoutubeAudioStream(url) {
   let info;


### PR DESCRIPTION
## Summary
- add configurable consent cookie to YouTube requests so info lookups no longer fail with HTTP 410
- document the new YOUTUBE_CONSENT_COOKIE environment variable for deployments that need a custom value

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d920ddf6608324a6ca513c94ac461c