### PR TITLE
Handle missing YouTube identity token by retrying without consent cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,7 @@ Discord with the `--change-music-tag <tag>` command. Playback starts at 1% volum
 `DEFAULT_VOLUME_PERCENT` (any value between 0 and 200).
 
 Use `--start-music <url>` to stream a custom audio source. The bot understands direct audio links as well as YouTube URLs.
-When streaming YouTube, the bot now sends a consent cookie by default so that regions requiring GDPR consent do not return HTTP
-410 errors. Override the cookie value with `YOUTUBE_CONSENT_COOKIE` if you need a different one or want to provide a full `CONSENT`
-string from your own browser session.
+When streaming YouTube, you can provide a consent cookie via the `YOUTUBE_CONSENT_COOKIE` environment variable if your region requires one to bypass GDPR-related HTTP 410 errors. The bot automatically retries requests without the cookie when YouTube rejects it for missing identity tokens, which prevents the "Cookie header used in request, but unable to find YouTube identity token" error introduced by recent YouTube changes.
 
 ## Docker
 

--- a/index.js
+++ b/index.js
@@ -446,11 +446,9 @@ function normalizeYoutubeConsentCookie(rawValue) {
   return trimmed;
 }
 
-const DEFAULT_YOUTUBE_CONSENT_COOKIE = 'SOCS=CAI';
-const YOUTUBE_CONSENT_COOKIE =
-  normalizeYoutubeConsentCookie(process.env.YOUTUBE_CONSENT_COOKIE) || DEFAULT_YOUTUBE_CONSENT_COOKIE;
+const YOUTUBE_CONSENT_COOKIE = normalizeYoutubeConsentCookie(process.env.YOUTUBE_CONSENT_COOKIE);
 
-const youtubeRequestHeaders = {
+const youtubeBaseRequestHeaders = {
   'User-Agent':
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
   'Accept-Language': 'en-US,en;q=0.9',
@@ -458,20 +456,54 @@ const youtubeRequestHeaders = {
   Referer: 'https://www.youtube.com'
 };
 
-if (YOUTUBE_CONSENT_COOKIE) {
-  youtubeRequestHeaders.Cookie = YOUTUBE_CONSENT_COOKIE;
+const YOUTUBE_REQUEST_HEADERS_WITH_COOKIE = YOUTUBE_CONSENT_COOKIE
+  ? Object.freeze({ ...youtubeBaseRequestHeaders, Cookie: YOUTUBE_CONSENT_COOKIE })
+  : null;
+
+const YOUTUBE_REQUEST_HEADERS_NO_COOKIE = Object.freeze({ ...youtubeBaseRequestHeaders });
+
+function isYoutubeIdentityTokenError(err) {
+  const message = err?.message;
+  if (typeof message !== 'string') {
+    return false;
+  }
+  return message.toLowerCase().includes('identity token');
 }
 
-const YOUTUBE_REQUEST_HEADERS = Object.freeze(youtubeRequestHeaders);
+async function loadYoutubeInfo(url, headers) {
+  return ytdl.getInfo(url, {
+    requestOptions: {
+      headers
+    }
+  });
+}
+
+async function getYoutubeInfoAndHeaders(url) {
+  if (YOUTUBE_REQUEST_HEADERS_WITH_COOKIE) {
+    try {
+      const info = await loadYoutubeInfo(url, YOUTUBE_REQUEST_HEADERS_WITH_COOKIE);
+      return { info, headers: YOUTUBE_REQUEST_HEADERS_WITH_COOKIE };
+    } catch (err) {
+      if (!isYoutubeIdentityTokenError(err)) {
+        throw err;
+      }
+      console.warn(
+        'Impossible de récupérer les informations YouTube avec le cookie fourni (jeton d\'identité manquant). Nouvel essai sans Cookie.'
+      );
+    }
+  }
+
+  const info = await loadYoutubeInfo(url, YOUTUBE_REQUEST_HEADERS_NO_COOKIE);
+  return { info, headers: YOUTUBE_REQUEST_HEADERS_NO_COOKIE };
+}
 
 async function getYoutubeAudioStream(url) {
   let info;
+  let requestHeaders;
   try {
-    info = await ytdl.getInfo(url, {
-      requestOptions: {
-        headers: YOUTUBE_REQUEST_HEADERS
-      }
-    });
+    const result = await getYoutubeInfoAndHeaders(url);
+    info = result.info;
+    requestHeaders = result.headers;
   } catch (err) {
     const detail = err?.message || err;
     throw new Error(`Impossible de récupérer les informations YouTube (${detail})`);
@@ -485,7 +517,7 @@ async function getYoutubeAudioStream(url) {
       highWaterMark: 1 << 25,
       dlChunkSize: 0,
       requestOptions: {
-        headers: YOUTUBE_REQUEST_HEADERS
+        headers: requestHeaders
       }
     });
   } catch (err) {


### PR DESCRIPTION
## Summary
- retry YouTube metadata requests without the consent cookie when the provided cookie is rejected for lacking an identity token
- document the new YouTube cookie behaviour and fallback in the README

## Testing
- not run (no automated tests available)


------
https://chatgpt.com/codex/tasks/task_e_68d92392ece88324890bb2f212833605