### PR TITLE
Switch to play-dl for reliable YouTube playback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,8 @@
         "ffmpeg-static": "^5.2.0",
         "node-fetch": "^2.7.0",
         "opusscript": "^0.0.8",
-        "prism-media": "^1.3.5",
-        "ytdl-core": "^4.11.5"
+        "play-dl": "^1.9.7",
+        "prism-media": "^1.3.5"
       }
     },
     "node_modules/@derhuerst/http-basic": {
@@ -995,28 +995,6 @@
         "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
     },
-    "node_modules/m3u8stream": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/m3u8stream/-/m3u8stream-0.8.6.tgz",
-      "integrity": "sha512-LZj8kIVf9KCphiHmH7sbFQTVe4tOemb202fWwvJwR9W5ENW/1hxJN6ksAWGhQgSBSa3jyWhnjKU1Fw1GaOdbyA==",
-      "license": "MIT",
-      "dependencies": {
-        "miniget": "^4.2.2",
-        "sax": "^1.2.4"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/miniget": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/miniget/-/miniget-4.2.3.tgz",
-      "integrity": "sha512-SjbDPDICJ1zT+ZvQwK0hUcRY4wxlhhNpHL9nJOB2MEAXRGagTljsO8MEDzQMTFf0Q8g4QNi8P9lEm/g7e+qgzA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/mp4box": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/mp4box/-/mp4box-0.5.4.tgz",
@@ -1114,6 +1092,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/play-audio": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/play-audio/-/play-audio-0.5.2.tgz",
+      "integrity": "sha512-ZAqHUKkQLix2Iga7pPbsf1LpUoBjcpwU93F1l3qBIfxYddQLhxS6GKmS0d3jV8kSVaUbr6NnOEcEMFvuX93SWQ==",
+      "license": "GPL-3.0"
+    },
+    "node_modules/play-dl": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/play-dl/-/play-dl-1.9.7.tgz",
+      "integrity": "sha512-KpgerWxUCY4s9Mhze2qdqPhiqd8Ve6HufpH9mBH3FN+vux55qSh6WJKDabfie8IBHN7lnrAlYcT/UdGax58c2A==",
+      "license": "GPL-3.0",
+      "dependencies": {
+        "play-audio": "^0.5.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/pngjs": {
@@ -1230,12 +1226,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/sax": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
-      "license": "ISC"
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",
@@ -1503,20 +1493,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/ytdl-core": {
-      "version": "4.11.5",
-      "resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-4.11.5.tgz",
-      "integrity": "sha512-27LwsW4n4nyNviRCO1hmr8Wr5J1wLLMawHCQvH8Fk0hiRqrxuIu028WzbJetiYH28K8XDbeinYW4/wcHQD1EXA==",
-      "license": "MIT",
-      "dependencies": {
-        "m3u8stream": "^0.8.6",
-        "miniget": "^4.2.2",
-        "sax": "^1.1.3"
-      },
-      "engines": {
-        "node": ">=12"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "ffmpeg-static": "^5.2.0",
     "node-fetch": "^2.7.0",
     "opusscript": "^0.0.8",
-    "prism-media": "^1.3.5",
-    "ytdl-core": "^4.11.5"
+    "play-dl": "^1.9.7",
+    "prism-media": "^1.3.5"
   }
 }


### PR DESCRIPTION
## Summary
- replace the legacy ytdl-core integration with play-dl and reuse the provided stream types when creating audio resources
- update custom and Jamendo stream helpers to propagate the desired StreamType and keep Discord volume handling intact
- add the latest play-dl dependency and drop ytdl-core from package metadata

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d92c17ea4c83248e0c7f7d89497fcb